### PR TITLE
make volume gui dependant on vol parameter

### DIFF
--- a/Classes/NodeProxyGui2.sc
+++ b/Classes/NodeProxyGui2.sc
@@ -254,7 +254,15 @@ NodeProxyGui2 {
 							sliderDict[key][\slider].value_(spec.unmap(val));
 						}.defer;
 					});
-			})
+				},
+				\vol, {
+					val = args[1][0];
+					{
+						volvalueBox.value_(val.max(0.0));
+						volslider.value_(val);
+					}.defer;
+				}
+			)
 		};
 		ndef.addDependant(slidersFunc);
 		window.onClose = {

--- a/Classes/extNodeProxy.sc
+++ b/Classes/extNodeProxy.sc
@@ -47,6 +47,11 @@
 		}
 	}
 
+	vol_ {|val|
+		super.vol_(val);
+		this.changed(\vol, [val]);
+	}
+
 	gui2{
 		NodeProxyGui2.new(this);
 	}

--- a/todo.md
+++ b/todo.md
@@ -5,7 +5,9 @@
 - Rework ignoreParams -> global/local ignores (look up Ndef.all)
 - Add local ignoreParam toggle to gui
 - Add skin/palette selector
-- NumberBox: clip values (ex. volume can easily be set to -123)
+- √ NumberBox: clip values (ex. volume can easily be set to -123). Kind of fixed but can still set .vol= -123 from code
+- Ndef(\yiyi).monitor.vol= 0.1 does not change volumeslider+numberbox. only Ndef(\yiyi).vol= 0.1 work for now
+- Consolidate all dependancy functions into one. (slidersFunc, infoFunc, playFunc)
 - Make A/B buttons to allow A/B testing two different parameter sets
 - NodeProxyGui2: seperate state into dict (old todo)
 - gui2's _stop_ is "free" and _free_ is "stop" .. oh my `8=()`


### PR DESCRIPTION
this will keep gui in sync with for example Ndef(\yiyi).vol= 0.1 but Ndef(\yiyi).monitor.vol= 0.1 will still not work. hm.