### PR TITLE
add limitUpdateRate feature - saves GUI redraw CPU

### DIFF
--- a/Classes/extNodeProxy.sc
+++ b/Classes/extNodeProxy.sc
@@ -53,7 +53,7 @@
 		}
 	}
 
-	gui2 {
-		^NodeProxyGui2.new(this)
+	gui2 { | limitUpdateRate = 0 |
+		^NodeProxyGui2.new(this, limitUpdateRate)
 	}
 }

--- a/HelpSource/Classes/NodeProxyGui2.schelp
+++ b/HelpSource/Classes/NodeProxyGui2.schelp
@@ -11,8 +11,10 @@ CLASSMETHODS::
 METHOD:: new
 
 ARGUMENT:: nodeproxy
+An link::Classes/Ndef:: instance.
 
 ARGUMENT:: limitUpdateRate
+The higher this value, the slower the interface will update. Set to a non-zero value to reduce the CPU cost of updating GUI elements. In seconds. 0.0 (default) will update instantly and 0.1 ten times per second.
 
 METHOD:: defaultIgnoreParams
 Parameters to be ignored when calling link::#-randomize:: and link::#-vary::.
@@ -28,7 +30,7 @@ At initialisation this array will be populated from defaultIgnoreParams.
 
 INSTANCEMETHODS::
 
-PRIVATE:: init, initFonts
+PRIVATE:: init, initFonts, makeInfoSection, makeTransportSection, makeParameterSection, makeSliders, ndefChanged, setUpDependencies, setUpParameters
 
 METHOD:: randomize
 Set parameters to random values. This will use the internal link::Classes/ControlSpec:: to figure out the range and ignore parameters in the array link::#*ignoreParams::.

--- a/HelpSource/Classes/NodeProxyGui2.schelp
+++ b/HelpSource/Classes/NodeProxyGui2.schelp
@@ -12,7 +12,7 @@ METHOD:: new
 
 ARGUMENT:: nodeproxy
 
-ARGUMENT:: updateRate
+ARGUMENT:: limitUpdateRate
 
 METHOD:: defaultIgnoreParams
 Parameters to be ignored when calling link::#-randomize:: and link::#-vary::.


### PR DESCRIPTION
keep track of parameters changed and their order and only update GUI widgets at a certain rate using SkipJack. survives CmdPeriod. also moved a few things around in .init.

questions:
* maybe limitUpdateRate should be a classvar? i.e. global for all gui2?
* is the extra complexity worth it?
* naming of methods, functions and variables could probably be improved.
