### PR TITLE
allow for embedding view in other views

### DIFF
--- a/Classes/NodeProxyGui2.sc
+++ b/Classes/NodeProxyGui2.sc
@@ -2,11 +2,11 @@ NodeProxyGui2 {
 
 	classvar <>defaultIgnoreParams = #[];
 
-	var <>ignoreParams;
-	var <window;
-
 	var <nodeProxy;
 	var params, paramViews;
+
+	var <>ignoreParams;
+	var <window;
 
 	var play, volslider, volvalueBox;
 	var header, parameterSection;
@@ -17,12 +17,11 @@ NodeProxyGui2 {
 	var nodeProxyChangedFunc, specChangedFunc;
 
 	// this is a normal constructor method
-	*new { | nodeproxy, limitUpdateRate = 0 |
-		^super.new.init(nodeproxy, limitUpdateRate)
+	*new { | nodeproxy, limitUpdateRate = 0, show = true |
+		^super.newCopyArgs(nodeproxy).init(limitUpdateRate, show)
 	}
 
-	init { | argNodeProxy, limitUpdateRate |
-		nodeProxy = argNodeProxy;
+	init { | limitUpdateRate, show |
 
 		this.initFonts();
 
@@ -42,8 +41,12 @@ NodeProxyGui2 {
 
 		this.makeParameterSection();
 
-		window.front;
+		if (show) {
+			window.front;
+		}
 	}
+
+	asView { ^window.asView }
 
 	setUpDependencies { | limitUpdateRate |
 		var limitOrder, limitDict, limitScheduler;

--- a/Classes/extNodeProxy.sc
+++ b/Classes/extNodeProxy.sc
@@ -1,7 +1,7 @@
 + NodeProxy {
 
-	gui2 { | limitUpdateRate = 0 |
-		^NodeProxyGui2.new(this, limitUpdateRate)
+	gui2 { | limitUpdateRate = 0, show = true |
+		^NodeProxyGui2.new(this, limitUpdateRate, show)
 	}
 
 }

--- a/HelpSource/Classes/NodeProxy.ext.schelp
+++ b/HelpSource/Classes/NodeProxy.ext.schelp
@@ -8,4 +8,8 @@ Creates a GUI for this NodeProxy. Shortcut for CODE::NodeProxyGui2.new(thisNodeP
 ARGUMENT:: limitUpdateRate
 The higher this value, the slower the interface will update. In seconds. Default is CODE::0:: which mean instant updates.
 
+ARGUMENT:: show
+If CODE::false::, don't display the window immediately, so that it can be
+embedded in other GUIs. Default is CODE::true::.
+
 RETURNS:: a LINK::Classes/NodeProxyGui2:: instance.

--- a/HelpSource/Classes/NodeProxyGui2.schelp
+++ b/HelpSource/Classes/NodeProxyGui2.schelp
@@ -32,6 +32,10 @@ An LINK::Classes/NodeProxy:: instance.
 ARGUMENT:: limitUpdateRate
 The higher this value, the slower the interface will update. In seconds. Default is CODE::0:: which mean instant updates.
 
+ARGUMENT:: show
+If CODE::false::, don't display the window immediately, so that it can be
+embedded in other GUIs. Default is CODE::true::.
+
 DISCUSSION::
 A non-zero limitUpdateRate will reduce the CPU cost of updating GUI elements. If there are many parameters continuously updated - say from a bunch of noisy sensor readings, a resonable limit is CODE::0.1::. That will force the GUI elements to only redraw ten times per second. CODE::0.1:: is also what the standard LINK::Classes/NdefGui:: uses internally. The limitUpdateRate can also be specified as an argument to the LINK::Classes/NodeProxy#-gui2:: method.
 
@@ -105,4 +109,33 @@ g.randomize;
 
 // Close the GUI
 g.close();
+
+// With show = false, the GUI is embeddable in larger views
+(
+var win = Window("two guis in the same window");
+Ndef(\yoyo, {|freq=300, amp=0.5, pan=0|
+	Pan2.ar(VarSaw.ar(freq), pos: pan, level: amp)
+});
+win.view.layout = HLayout(
+	NodeProxyGui2(Ndef(\yiyi), show: false),
+	NodeProxyGui2(Ndef(\yoyo), show: false)
+);
+win.front;
+)
+
+(
+var win = Window("an ndef and something else");
+var graphics = UserView().drawFunc_({ |v|
+	{:Rect(x,y,20.rand,20.rand), 
+		x <- (0,20..v.bounds.width), y <- (0,20..v.bounds.height)
+	}.do { |r|
+		Pen.fillColor_(Color.rand).fillOval(r)
+	}
+});
+win.view.layout = VLayout(
+	[graphics, s: 2], 
+	NodeProxyGui2(Ndef(\yiyi), show: false)
+);
+win.front
+)
 ::


### PR DESCRIPTION
Permits embedding NodeProxyGui2 in other views.
Doesn't break previous interface.

Adds show=true as constructor arg. If show=false, the window is not
displayed. Implements .asView, which returns window.asView, so that
NodeProxyGui2 can directly be included in more complex guis.

```supercollider
Ndef(\test) { |freq=440, amp=0.1| SinOsc.ar(freq) * amp };

(
// embed in bigger gui: create with show = false
var npgui = Ndef(\test).gui2(show: false);
View().layout_(VLayout(
    StaticText().string_("EXTRA BANNER"),
    npgui
);
)

(
// or shorter
View().layout_(VLayout(
    StaticText().string_("EXTRA BANNER"),
    Ndef(\test).gui2(show: false)
);
)

// immediate showing still works ofc
Ndef(\test).gui2
```
