### PR TITLE
bugfix for numberboxes using array of parameters

### DIFF
--- a/Classes/NodeProxyGui2.sc
+++ b/Classes/NodeProxyGui2.sc
@@ -473,7 +473,7 @@ NodeProxyGui2 {
 					.action_({ | obj |
 						var val = spec.wrapAt(n).constrain(obj.value);
 						sliders[n].value_(spec.wrapAt(n).unmap(val));
-						nodeProxy.set(key, val);
+						nodeProxy.seti(key, n, val);
 					})
 					.decimals_(4)
 					.value_(spec.wrapAt(n).constrain(pVal));


### PR DESCRIPTION
problem discovered by dietcv and reported in https://github.com/madskjeldgaard/nodeproxygui2/issues/48
here's a proposed fix.  i believe it's correct.