### PR TITLE
feat: add showInfo and showTransport params to NodeProxyGui2

### DIFF
--- a/Classes/NodeProxyGui2.sc
+++ b/Classes/NodeProxyGui2.sc
@@ -20,11 +20,11 @@ NodeProxyGui2 {
 	var nodeProxyChangedFunc, specChangedFunc;
 
 	// this is a normal constructor method
-	*new { | nodeproxy, limitUpdateRate = 0, show = true, collapseArrays = false |
-		^super.newCopyArgs(nodeproxy, collapseArrays).init(limitUpdateRate, show)
+	*new { | nodeproxy, limitUpdateRate = 0, show = true, collapseArrays = false, showInfo = true, showTransport = true |
+		^super.newCopyArgs(nodeproxy, collapseArrays).init(limitUpdateRate, show, showInfo, showTransport)
 	}
 
-	init { | limitUpdateRate, show |
+	init { | limitUpdateRate, show, showInfo, showTransport |
 
 		this.initFonts();
 
@@ -33,10 +33,21 @@ NodeProxyGui2 {
 
 		window = Window.new(nodeProxy.key);
 		window.layout = VLayout.new(
-			this.makeInfoSection(),
-			this.makeTransportSection(),
 			// parameterSection gets added here in makeParameterSection
 		);
+
+		if (showInfo) {
+			window.layout.add(this.makeInfoSection())
+		} {
+			if (nodeProxy.key.notNil) {
+				header = StaticText.new().string_(nodeProxy.key);
+				window.layout.add(header);
+			}
+		};
+
+		if (showTransport) {
+			window.layout.add(this.makeTransportSection())
+		};
 
 		window.view.children.do{ | c | c.font = if(c == header, headerFont, font) };
 		headerHeight = window.view.sizeHint.height;

--- a/Classes/extNodeProxy.sc
+++ b/Classes/extNodeProxy.sc
@@ -1,7 +1,7 @@
 + NodeProxy {
 
-	gui2 { | limitUpdateRate = 0, show = true, collapseArrays = false |
-		^NodeProxyGui2.new(this, limitUpdateRate, show, collapseArrays)
+	gui2 { | limitUpdateRate = 0, show = true, collapseArrays = false, showInfo = true, showTransport = true |
+		^NodeProxyGui2.new(this, limitUpdateRate, show, collapseArrays, showInfo, showTransport)
 	}
 
 }

--- a/HelpSource/Classes/NodeProxy.ext.schelp
+++ b/HelpSource/Classes/NodeProxy.ext.schelp
@@ -19,6 +19,6 @@ ARGUMENT:: showInfo
 If CODE::false::, the info section (showing the node proxy name, fadeTime, channel count and rate) is hidden. Default is CODE::true::.
 
 ARGUMENT:: showTransport
-If CODE::false::, the transport section (play, stop, end, record buttons and volume slider) is hidden. Default is CODE::true::. Useful when the node proxy is controlled externally.
+If CODE::false::, the transport section (play, clear, free, etc...) is hidden. Default is CODE::true::.
 
 RETURNS:: a LINK::Classes/NodeProxyGui2:: instance.

--- a/HelpSource/Classes/NodeProxy.ext.schelp
+++ b/HelpSource/Classes/NodeProxy.ext.schelp
@@ -16,7 +16,7 @@ ARGUMENT:: collapseArray
 When CODE::true::, arrays of parameters will be shown as single line LINK::Classes/TextField::s. The default (CODE::false::) will show arrays of parameters as separate silders.
 
 ARGUMENT:: showInfo
-If CODE::false::, the info section (showing the node proxy name and source code) is hidden. Default is CODE::true::.
+If CODE::false::, the info section (showing the node proxy name, fadeTime, channel count and rate) is hidden. Default is CODE::true::.
 
 ARGUMENT:: showTransport
 If CODE::false::, the transport section (play, stop, end, record buttons and volume slider) is hidden. Default is CODE::true::. Useful when the node proxy is controlled externally.

--- a/HelpSource/Classes/NodeProxy.ext.schelp
+++ b/HelpSource/Classes/NodeProxy.ext.schelp
@@ -15,4 +15,10 @@ embedded in other GUIs. Default is CODE::true::.
 ARGUMENT:: collapseArray
 When CODE::true::, arrays of parameters will be shown as single line LINK::Classes/TextField::s. The default (CODE::false::) will show arrays of parameters as separate silders.
 
+ARGUMENT:: showInfo
+If CODE::false::, the info section (showing the node proxy name and source code) is hidden. Default is CODE::true::.
+
+ARGUMENT:: showTransport
+If CODE::false::, the transport section (play, stop, end, record buttons and volume slider) is hidden. Default is CODE::true::. Useful when the node proxy is controlled externally.
+
 RETURNS:: a LINK::Classes/NodeProxyGui2:: instance.

--- a/HelpSource/Classes/NodeProxy.ext.schelp
+++ b/HelpSource/Classes/NodeProxy.ext.schelp
@@ -16,7 +16,7 @@ ARGUMENT:: collapseArray
 When CODE::true::, arrays of parameters will be shown as single line LINK::Classes/TextField::s. The default (CODE::false::) will show arrays of parameters as separate silders.
 
 ARGUMENT:: showInfo
-If CODE::false::, the info section (showing the node proxy name, fadeTime, channel count and rate) is hidden. Default is CODE::true::.
+If CODE::false::, the info section (showing fadeTime, channel count and rate) is hidden. Default is CODE::true::.
 
 ARGUMENT:: showTransport
 If CODE::false::, the transport section (play, clear, free, etc...) is hidden. Default is CODE::true::.

--- a/HelpSource/Classes/NodeProxyGui2.schelp
+++ b/HelpSource/Classes/NodeProxyGui2.schelp
@@ -39,6 +39,12 @@ embedded in other GUIs. Default is CODE::true::.
 ARGUMENT:: collapseArrays
 When CODE::true::, arrays of parameters will be shown as single line LINK::Classes/TextField::s. The default (CODE::false::) will show arrays of parameters as separate silders.
 
+ARGUMENT:: showInfo
+If CODE::false::, the info section (showing the node proxy name and source code) is hidden. When hidden and the node proxy has a key, a plain text header with the key is shown instead. Default is CODE::true::.
+
+ARGUMENT:: showTransport
+If CODE::false::, the transport section (play, stop, end, record buttons and volume slider) is hidden. Default is CODE::true::. Useful when the node proxy is controlled externally and transport interaction is not needed.
+
 DISCUSSION::
 A non-zero limitUpdateRate will reduce the CPU cost of updating GUI elements. If there are many parameters continuously updated - say from a bunch of noisy sensor readings, a reasonable limit is CODE::0.1::. That will force the GUI elements to only redraw ten times per second. CODE::0.1:: is also what the standard LINK::Classes/NdefGui:: uses internally. The limitUpdateRate can also be specified as an argument to the LINK::Classes/NodeProxy#-gui2:: method.
 
@@ -137,6 +143,19 @@ g.randomize;
 
 // Close the GUI
 g.close();
+
+// Hide the info and transport sections — useful when embedding in a larger GUI
+// or when the node proxy is controlled externally
+(
+var win = Window("parameter controls only");
+Ndef(\yiyi, {|freq=300, amp=0.5, pan=0|
+	Pan2.ar(SinOsc.ar(freq), pos: pan, level: amp)
+});
+win.view.layout = VLayout(
+	NodeProxyGui2(Ndef(\yiyi), show: false, showInfo: false, showTransport: false)
+);
+win.front;
+)
 
 // With show = false, the GUI is embeddable in larger views
 (

--- a/HelpSource/Classes/NodeProxyGui2.schelp
+++ b/HelpSource/Classes/NodeProxyGui2.schelp
@@ -40,7 +40,7 @@ ARGUMENT:: collapseArrays
 When CODE::true::, arrays of parameters will be shown as single line LINK::Classes/TextField::s. The default (CODE::false::) will show arrays of parameters as separate silders.
 
 ARGUMENT:: showInfo
-If CODE::false::, the info section (showing the node proxy name, fadeTime, channel count and rate) is hidden. When hidden and the node proxy has a key, a plain text header with the key is shown instead. Default is CODE::true::.
+If CODE::false::, the info section (showing fadeTime, channel count and rate) is hidden. When hidden and the node proxy has a key, a plain text header with the key is shown instead. Default is CODE::true::.
 
 ARGUMENT:: showTransport
 If CODE::false::, the transport section (play, clear, free, etc...) is hidden. Default is CODE::true::.

--- a/HelpSource/Classes/NodeProxyGui2.schelp
+++ b/HelpSource/Classes/NodeProxyGui2.schelp
@@ -40,10 +40,10 @@ ARGUMENT:: collapseArrays
 When CODE::true::, arrays of parameters will be shown as single line LINK::Classes/TextField::s. The default (CODE::false::) will show arrays of parameters as separate silders.
 
 ARGUMENT:: showInfo
-If CODE::false::, the info section (showing the node proxy name and source code) is hidden. When hidden and the node proxy has a key, a plain text header with the key is shown instead. Default is CODE::true::.
+If CODE::false::, the info section (showing the node proxy name, fadeTime, channel count and rate) is hidden. When hidden and the node proxy has a key, a plain text header with the key is shown instead. Default is CODE::true::.
 
 ARGUMENT:: showTransport
-If CODE::false::, the transport section (play, stop, end, record buttons and volume slider) is hidden. Default is CODE::true::. Useful when the node proxy is controlled externally and transport interaction is not needed.
+If CODE::false::, the transport section (play, clear, free, etc...) is hidden. Default is CODE::true::.
 
 DISCUSSION::
 A non-zero limitUpdateRate will reduce the CPU cost of updating GUI elements. If there are many parameters continuously updated - say from a bunch of noisy sensor readings, a reasonable limit is CODE::0.1::. That will force the GUI elements to only redraw ten times per second. CODE::0.1:: is also what the standard LINK::Classes/NdefGui:: uses internally. The limitUpdateRate can also be specified as an argument to the LINK::Classes/NodeProxy#-gui2:: method.
@@ -145,7 +145,6 @@ g.randomize;
 g.close();
 
 // Hide the info and transport sections — useful when embedding in a larger GUI
-// or when the node proxy is controlled externally
 (
 var win = Window("parameter controls only");
 Ndef(\yiyi, {|freq=300, amp=0.5, pan=0|


### PR DESCRIPTION
## Summary

When building larger GUIs that embed multiple NodeProxyGui2 instances, the info and
transport sections consume significant vertical space and are not always needed. For example when when the GUI is one panel among many.

This adds two optional boolean parameters to `NodeProxyGui2.new` (and the `.gui2`
shortcut) to allow hiding each section independently.

- `showInfo` (default: `true`) — when `false`, the info section is hidden. A plain
  text header with the node proxy key is shown instead, so the window still has a
  readable title when embedded.
- `showTransport` (default: `true`) — when `false`, the transport buttons and
  volume slider are hidden.
Both parameters default to `true`, so existing behaviour is unchanged.

## Changes

- `showInfo` (default: `true`) — when `false`, the info section is hidden. A plain
  text header with the node proxy key is shown instead, so the window still has a
  readable title when embedded.
- `showTransport` (default: `true`) — when `false`, the transport buttons and
  volume slider are hidden.
Both parameters default to `true`, so existing behaviour is unchanged.

## Usage example

```supercollider
Ndef(\zz, {|freq = 440, amp = 0.5, pan = 0|
    Pan2.ar(SinOsc.ar(freq), pan, amp)
});

// Hide the info section only
Ndef(\zz).gui2(showInfo: false);

// Hide both sections — parameter controls only
Ndef(\zz).gui2(showInfo: false, showTransport: false);
```

## Help file updates

Both NodeProxyGui2.schelp and NodeProxy.ext.schelp are updated with argument
descriptions and an example.

## Alternatives

**A:** Don't add two init vars but instead use setters only and rebuild the UI when set. 
**B:** Pass an options Array or Dict to the constructor (`*new { |nodeproxy ... args|`).  This would also leave some room for additional UI options like `fixedSliderWidth` or `labelWidth`)