### PR TITLE
fix: preserve parameter definition order

### DIFF
--- a/Classes/NodeProxyGui2.sc
+++ b/Classes/NodeProxyGui2.sc
@@ -434,7 +434,9 @@ NodeProxyGui2 {
 		});
 
 		paramViews.clear;
-		params.sortedKeysValuesDo{ | key, spec |
+		nodeProxy.getKeysValues.select{ | kv | params.includesKey(kv[0]) }.do{ | keyVal |
+			var key = keyVal[0];
+			var spec = params[key];
 			var layout, paramVal;
 			var slider, valueBox, textField, staticText;
 			var sliders, valueBoxes;


### PR DESCRIPTION
## Summary
`makeParameterViews` iterates parameters using `params.sortedKeysValuesDo`, which sorts keys alphabetically before iterating. This means the order of sliders in the GUI is always alphabetical, regardless of the order in which parameters are defined in the SynthDef or Ndef.
## Reproduction
```supercollider
(
Ndef(\yiyi, { |freq = 300, amp = 0.5, pan = 0|
    Pan2.ar(SinOsc.ar(freq), pos: pan, level: amp)
});
Ndef(\yiyi).gui2;
)
```
The GUI shows sliders in alphabetical order: `amp`, `freq`, `pan` instead of the definition order `freq`, `amp`, `pan`. For a synth with many parameters this makes the GUI hard to read, because the visual layout no longer corresponds to the structure of the SynthDef.

## Fix
Iterate via `nodeProxy.getKeysValues` instead, which returns keys in definition order, and filter to only the keys present in `params`:
```supercollider
// Before
params.sortedKeysValuesDo{ |key, spec|
    ...
}
// After
nodeProxy.getKeysValues.select{ |kv| params.includesKey(kv[0]) }.do{ |keyVal|
    var key = keyVal[0];
    var spec = params[key];
    ...
}
```
`NodeProxy.getKeysValues` is part of the standard class library and returns key-value pairs in the order the parameters were registered, matching the definition order of the UGen function arguments.

No behaviour change beyond parameter order. All existing functionality (spec lookup, slider types, value boxes) is unaffected.