### PR TITLE
feat: fall back to getSpec for specs registered via addSpec

### DIFF
--- a/Classes/NodeProxyGui2.sc
+++ b/Classes/NodeProxyGui2.sc
@@ -359,10 +359,10 @@ NodeProxyGui2 {
 
 				spec = case
 				{ val.isNumber } {
-					(nodeProxy.specs.at(key) ?? { Spec.specs.at(key) } ?? { nodeProxy.respondsTo(\getSpec).if { nodeProxy.getSpec(key) } }).asSpec
+					(nodeProxy.specs.at(key) ?? { nodeProxy.respondsTo(\getSpec).if { nodeProxy.getSpec(key) } } ?? { Spec.specs.at(key) }).asSpec
 				}
 				{ val.isArray } {
-					(nodeProxy.specs.at(key) ?? { Spec.specs.at(key) } ?? { nodeProxy.respondsTo(\getSpec).if { nodeProxy.getSpec(key) } }).asSpec.dup(val.size)
+					(nodeProxy.specs.at(key) ?? { nodeProxy.respondsTo(\getSpec).if { nodeProxy.getSpec(key) } } ?? { Spec.specs.at(key) }).asSpec.dup(val.size)
 				}
 				{ val.isKindOf(Bus) } {
 					if(val.rate == \control, { \controlbus }, { \audiobus }).asSpec
@@ -676,7 +676,7 @@ NodeProxyGui2 {
 			var spec;
 
 			if(this.paramPresentInArray(key, ignored).not, {
-				spec = (nodeProxy.specs.at(key) ?? { Spec.specs.at(key) } ?? { nodeProxy.respondsTo(\getSpec).if { nodeProxy.getSpec(key) } }).asSpec;
+				spec = (nodeProxy.specs.at(key) ?? { nodeProxy.respondsTo(\getSpec).if { nodeProxy.getSpec(key) } } ?? { Spec.specs.at(key) }).asSpec;
 				if(val.isNumber, {
 					accepted.put(key, spec)
 				}, {

--- a/Classes/NodeProxyGui2.sc
+++ b/Classes/NodeProxyGui2.sc
@@ -359,10 +359,10 @@ NodeProxyGui2 {
 
 				spec = case
 				{ val.isNumber } {
-					(nodeProxy.specs.at(key) ?? { Spec.specs.at(key) }).asSpec
+					(nodeProxy.specs.at(key) ?? { Spec.specs.at(key) } ?? { nodeProxy.respondsTo(\getSpec).if { nodeProxy.getSpec(key) } }).asSpec
 				}
 				{ val.isArray } {
-					(nodeProxy.specs.at(key) ?? { Spec.specs.at(key) }).asSpec.dup(val.size)
+					(nodeProxy.specs.at(key) ?? { Spec.specs.at(key) } ?? { nodeProxy.respondsTo(\getSpec).if { nodeProxy.getSpec(key) } }).asSpec.dup(val.size)
 				}
 				{ val.isKindOf(Bus) } {
 					if(val.rate == \control, { \controlbus }, { \audiobus }).asSpec
@@ -676,7 +676,7 @@ NodeProxyGui2 {
 			var spec;
 
 			if(this.paramPresentInArray(key, ignored).not, {
-				spec = (nodeProxy.specs.at(key) ?? { Spec.specs.at(key) }).asSpec;
+				spec = (nodeProxy.specs.at(key) ?? { Spec.specs.at(key) } ?? { nodeProxy.respondsTo(\getSpec).if { nodeProxy.getSpec(key) } }).asSpec;
 				if(val.isNumber, {
 					accepted.put(key, spec)
 				}, {


### PR DESCRIPTION
## Summary
`NodeProxyGui2` resolves slider specs using a two-step lookup:
1. `nodeProxy.specs.at(key)` — specs set directly on the proxy's internal dictionary
2. `Spec.specs.at(key)` — the global spec dictionary

This misses specs registered via `NodeProxy.addSpec` (provided by the [JITLibExtensions](https://github.com/supercollider-quarks/JITLibExtensions) quark), which stores them through `nodeProxy.server.set` and retrieves them via `nodeProxy.getSpec(key)`. Parameters registered this way silently fall back to a default spec, giving the slider an incorrect range.
## Reproduction
```supercollider
(
Ndef(\yiyi, { |freq = 300, amp = 0.5, pan = 0|
    Pan2.ar(SinOsc.ar(freq), pos: pan, level: amp)
});
Ndef(\yiyi).addSpec(\freq, [200, 8000, \exp]);
Ndef(\yiyi).gui2;
)
```
The `freq` slider shows the default global spec range instead of the 200–8000 Hz exponential range registered with `.addSpec`.
## Fix
Add `nodeProxy.getSpec(key)` as a third fallback in all three spec lookup sites, guarded by `respondsTo` so the behaviour is unchanged when JITLibExtensions is not installed:
```supercollider
// Before
(nodeProxy.specs.at(key) ?? { Spec.specs.at(key) }).asSpec
// After
(nodeProxy.specs.at(key) ?? { Spec.specs.at(key) } ?? {
    nodeProxy.respondsTo(\getSpec).if { nodeProxy.getSpec(key) }
}).asSpec
```
No behaviour change when the first two lookups succeed, or when JITLibExtensions is not installed.