### PR TITLE
fix: prevent parameter slider height growth when embedded in external layout

### DIFF
--- a/Classes/NodeProxyGui2.sc
+++ b/Classes/NodeProxyGui2.sc
@@ -347,7 +347,6 @@ NodeProxyGui2 {
 	makeParameterSection {
 		var excluded = defaultExcludeParams ++ prExcludeParams;
 		var numParams = params.flatSize;
-		var sectionSize;
 
 		params.do{ | spec | spec.removeDependant(specChangedFunc) };
 		params.clear;
@@ -385,18 +384,20 @@ NodeProxyGui2 {
 		};
 
 		if(parameterSection.notNil, { parameterSection.remove });
-		parameterSection = this.makeParameterViews();
-		sectionSize = parameterSection.sizeHint;
-		parameterSection = ScrollView.new().canvas_(parameterSection);
-		window.layout.add(parameterSection, 1);
-
-		if(window.view.parent.isNil, {  //resize only when not embedded
-			window.view.bounds = window.view.bounds.resizeTo(
-				window.view.bounds.width,
-				(sectionSize.height + headerHeight + 30)  //30 compensate default spacing
-				.min(Window.availableBounds.height)
-			);
+		parameterSection = this.makeParameterViews().resizeToHint;
+		if(parameterSection.sizeHint.height > (Window.availableBounds.height * 0.5), {
+			var sv = ScrollView.new().canvas_(parameterSection);
+			sv.fixedHeight_((Window.availableBounds.height * 0.5).asInteger);
+			parameterSection = sv;
 		});
+		window.layout.add(parameterSection, 0);
+		{
+			if(parameterSection.isKindOf(ScrollView), {
+				window.view.maxHeight_(window.view.sizeHint.height)
+			}, {
+				window.view.fixedHeight_(window.view.sizeHint.height)
+			})
+		}.defer(0.07);
 	}
 
 	makeParameterViews {

--- a/Classes/NodeProxyGui2.sc
+++ b/Classes/NodeProxyGui2.sc
@@ -386,6 +386,9 @@ NodeProxyGui2 {
 
 		if(parameterSection.notNil, { parameterSection.remove });
 		innerView = this.makeParameterViews().resizeToHint;
+		// Pin height to sizeHint so sliders cannot grow when the parent layout
+		// distributes surplus vertical space. When the natural height exceeds
+		// half the screen, a ScrollView provides the necessary overflow container.
 		if(innerView.sizeHint.height > (Window.availableBounds.height * 0.5), {
 			parameterSection = ScrollView.new().canvas_(innerView);
 			parameterSection.maxHeight_((Window.availableBounds.height * 0.5).asInteger);

--- a/Classes/NodeProxyGui2.sc
+++ b/Classes/NodeProxyGui2.sc
@@ -347,6 +347,7 @@ NodeProxyGui2 {
 	makeParameterSection {
 		var excluded = defaultExcludeParams ++ prExcludeParams;
 		var numParams = params.flatSize;
+		var innerView;
 
 		params.do{ | spec | spec.removeDependant(specChangedFunc) };
 		params.clear;
@@ -384,17 +385,18 @@ NodeProxyGui2 {
 		};
 
 		if(parameterSection.notNil, { parameterSection.remove });
-		parameterSection = this.makeParameterViews().resizeToHint;
-		if(parameterSection.sizeHint.height > (Window.availableBounds.height * 0.5), {
-			var sv = ScrollView.new().canvas_(parameterSection);
-			sv.fixedHeight_((Window.availableBounds.height * 0.5).asInteger);
-			parameterSection = sv;
+		innerView = this.makeParameterViews().resizeToHint;
+		if(innerView.sizeHint.height > (Window.availableBounds.height * 0.5), {
+			parameterSection = ScrollView.new().canvas_(innerView);
+			parameterSection.maxHeight_((Window.availableBounds.height * 0.5).asInteger);
+			window.layout.add(parameterSection, 1);
+		}, {
+			parameterSection = innerView;
+			window.layout.add(parameterSection, 0);
 		});
-		window.layout.add(parameterSection, 0);
 		{
-			if(parameterSection.isKindOf(ScrollView), {
-				window.view.maxHeight_(window.view.sizeHint.height)
-			}, {
+			innerView.fixedHeight_(innerView.sizeHint.height);
+			if(parameterSection.isKindOf(ScrollView).not, {
 				window.view.fixedHeight_(window.view.sizeHint.height)
 			})
 		}.defer(0.07);


### PR DESCRIPTION
## Problem
When `NodeProxyGui2` is embedded in an external layout, the parameter
section expands to fill all available vertical space as the window is
resized. Sliders grow disproportionately, regardless of how many
parameters a proxy exposes.

The root cause is that the parameter view is added to the window layout
with stretch factor `1` and no `maxHeight` constraint, so Qt distributes
all surplus vertical space to it.

## Solution
The parameter view's height is now pinned to its natural `sizeHint` via
a deferred `fixedHeight_` call. When the natural height would exceed
50 % of the available screen height, a `ScrollView` is added as a
container and capped at that threshold, a necessary consequence of
constraining height rather than a separate feature.

## Changed method

makeParameterSection

## Demonstration
```supercollider
(
var win, proxyView;
Ndef(\demo, { |a=0,b=0,c=0,|
	SinOsc.ar(440) * 0.1 ! 2
});
win = Window("NodeProxyGui2 demo", Rect(100, 100, 400, 300)).front;
proxyView = Ndef(\demo).gui2(0, false);
win.layout = VLayout(proxyView);
)
```

### Before

drag the window taller: sliders grow to fill the extra space.

<img width="495" height="430" alt="Before" src="https://github.com/user-attachments/assets/d51bae44-e64d-4fe8-97c6-d3e69257f3cc" />


### After

sliders stay at their natural size regardless of window height.

<img width="495" height="430" alt="After" src="https://github.com/user-attachments/assets/4f8a4645-601c-4182-97ad-6ba83f697056" />