### PR TITLE
refactor: clean up makeTransportSection

### DIFF
--- a/Classes/NodeProxyGui2.sc
+++ b/Classes/NodeProxyGui2.sc
@@ -265,53 +265,26 @@ NodeProxyGui2 {
 	}
 
 	makeTransportSection {
-		var clear, send, scope, free, popup;
+		var minW = 55;
+		var proxyButtons, popup;
 
 		play = Button.new()
 		.states_([
 			["play"],
 			["stop", Color.black, Color.grey(0.5, 0.5)],
 		])
-		.action_({ | obj |
-			if(obj.value == 1, {
-				nodeProxy.play
-			}, {
-				nodeProxy.stop
-			})
+		.action_({ |obj|
+			if(obj.value == 1, { nodeProxy.play }, { nodeProxy.stop })
 		})
-		.value_(nodeProxy.isMonitoring.binaryValue);
+		.value_(nodeProxy.isMonitoring.binaryValue)
+		.minWidth_(minW);
 
-		clear = Button.new()
-		.states_(#[
-			["clear"]
-		])
-		.action_({ | obj |
-			nodeProxy.clear
-		});
-
-		send = Button.new()
-		.states_(#[
-			["send"]
-		])
-		.action_({ | obj |
-			nodeProxy.send
-		});
-
-		scope = Button.new()
-		.states_(#[
-			["scope"]
-		])
-		.action_({ | obj |
-			nodeProxy.scope
-		});
-
-		free = Button.new()
-		.states_(#[
-			["free"]
-		])
-		.action_({ | obj |
-			nodeProxy.free
-		});
+		proxyButtons = #[\clear, \free, \scope, \send].collect { |sym|
+			Button.new()
+			.states_([[sym.asString]])
+			.action_({ nodeProxy.perform(sym) })
+			.minWidth_(minW)
+		};
 
 		popup = PopUpMenu.new()
 		.allowsReselection_(true)
@@ -322,7 +295,7 @@ NodeProxyGui2 {
 			"document",
 			"post",
 		])
-		.action_({ | obj |
+		.action_({ |obj|
 			switch(obj.value,
 				0, { this.defaults() },
 				1, { this.randomize() },
@@ -331,17 +304,13 @@ NodeProxyGui2 {
 				4, { this.asCode.postln },
 			)
 		})
-		.keyDownAction_({ | obj, char |
-			if(char == Char.ret, {
-				obj.doAction
-			})
+		.keyDownAction_({ |obj, char|
+			if(char == Char.ret, { obj.doAction })
 		})
 		.canFocus_(true)
 		.fixedWidth_(25);
 
-		^HLayout.new(
-			play, clear, free, scope, send, popup
-		)
+		^HLayout.new(*([play] ++ proxyButtons ++ [popup]))
 	}
 
 	makeParameterSection {


### PR DESCRIPTION
## Summary
`makeTransportSection` contained four near-identical `Button` blocks differing only in label and the proxy method they called. This PR removes the duplication and adds an explicit `minWidth` constraint to all transport buttons.

## Changes
- The four single-state buttons (`clear`, `free`, `scope`, `send`) are now built with a single `collect` over an array of symbols, using `perform` to call the matching method on the node proxy. This removes approximately 37 lines of repetitive code.
- All five transport buttons (`play`, `clear`, `free`, `scope`, `send`) now have an explicit `minWidth_(55)` constraint. Without it, Qt applies a default minimum width that is wider than the button text requires, causing the widget to occupy more horizontal space than necessary.

## Before / After

**Before** (four identical blocks):
```supercollider
clear = Button.new()
.states_(#[["clear"]])
.action_({ |obj| nodeProxy.clear });
send = Button.new()
.states_(#[["send"]])
.action_({ |obj| nodeProxy.send });
// ... and so on
```

**After** (single collect):

```
proxyButtons = #[\clear, \free, \scope, \send].collect { |sym|
    Button.new()
    .states_([[sym.asString]])
    .action_({ nodeProxy.perform(sym) })
    .minWidth_(minW)
};
^HLayout.new(*([play] ++ proxyButtons ++ [popup]))

```
Without minWidth, the transport row is wider than it needs to be. With this change, buttons size to fit their labels.